### PR TITLE
Remove obsolete lines that caused a uiComponent hard error

### DIFF
--- a/view/adminhtml/ui_component/kiwicommerce_login_as_customer_index.xml
+++ b/view/adminhtml/ui_component/kiwicommerce_login_as_customer_index.xml
@@ -15,11 +15,6 @@
 -->
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
-    <argument name="context" xsi:type="configurableObject">
-
-        <argument name="class" xsi:type="string">Magento\Framework\View\Element\UiComponent\Context</argument>
-        <argument name="namespace" xsi:type="string">kiwicommerce_login_as_customer_index</argument>
-    </argument>
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
             <item name="provider" xsi:type="string">


### PR DESCRIPTION
These lines caused the application to break in Magento 2.3.3.

To replicate, you would go to Customers > Login as Customer. Upon clicking that, you would be greeted with an application error, of which here are the logs:
```
{"0":"Class argument is invalid: Magento\\Framework\\View\\Element\\UiComponent\\Context","1":"<pre>#1 Magento\\Framework\\Data\\Argument\\InterpreterInterface\\Proxy->evaluate() called at [vendor\/magento\/framework\/Data\/Argument\/Interpreter\/Composite.php:61]\n#2 Magento\\Framework\\Data\\Argument\\Interpreter\\Composite->evaluate() called at [vendor\/magento\/module-ui\/Config\/Data.php:164]\n#3 Magento\\Ui\\Config\\Data->evaluateComponentArguments() called at [vendor\/magento\/module-ui\/Config\/Data.php:111]\n#4
...
```

The resolution was removing the `context` argument from the uiComponent. All functionality (delete and filter) still seems to work as expected.